### PR TITLE
feat(IAM): improve setup script with minimum IAM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ This guide provides step-by-step instructions on how to deploy the `Document Pro
 
 ### Prerequisites
 To deploy this example you need:
-- A [Google Cloud project](https://cloud.google.com/docs/overview#projects) with billing enabled.
 - An account with the [Project Owner role](https://cloud.google.com/iam/docs/understanding-roles#resource-manager-roles) on the project. This grants the necessary permissions to create and manage resources.
 - An account with the [Organization Policy Admin](https://cloud.google.com/resource-manager/docs/organization-policy/creating-managing-policies) role assigned within the organization, which is required to modify the following organization policies:
     * `compute.vmExternalIpAccess`
@@ -38,8 +37,24 @@ To deploy this example you need:
 
 
 ### Deploying the Sample
-1. Open [Cloud Shell](https://console.cloud.google.com/cloudshell)
+1. To deploy this repository using an online terminal with software preconfigured, use [Cloud Shell](https://shell.cloud.google.com/?show=ide%2Cterminal).
+
+   To deploy this repository using a local terminal:
+    1. [install](https://cloud.google.com/sdk/docs/install) and [initialize](https://cloud.google.com/sdk/docs/initializing) the gcloud CLI
+    1. [install Terraform](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/install-cli)
+    1. [install the git CLI](https://github.com/git-guides/install-git)
+    1. [set up application default credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
+
+1. [Create or select a Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+
+1. Make sure that [billing is enabled for your Google Cloud project](https://cloud.google.com/billing/docs/how-to/verify-billing-enabled#console).
+
+
 1. Clone this repository
+
+    ```sh
+    git clone https://github.com/GoogleCloudPlatform/document-processing-and-understanding.git
+    ```
 1. Navigate to the Sample Directory:
 
     ```sh
@@ -47,13 +62,19 @@ To deploy this example you need:
     ```
     Where `<YOUR_REPOSITORY>` is the path to the directory where you cloned this repository.
 
-1. Set environment variable: `PROJECT_ID`
+1. Set the following environment variables:
 
     ```sh
     export PROJECT_ID="<your Google Cloud project id>"
-    export REGION="<your Google Cloud region>"
+    export REGION="<your Google Cloud region for the deployment>"
+    export SERVICE_ACCOUNT_ID="your service account identity that will be used to deploy resources"
     ```
-1. Run the following script to setup your environment and your cloud project for running terraform:
+
+1. Run the following script to setup your environment and your cloud project for running terraform. This configures the following:
+    - Enable the required APIs defined in `project_apis.txt`.
+    - Enable the required IAM roles on the service account you'll use to deploy terraform resources, defined in `project_roles.txt`.
+    - Authenticate the [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) with the credentials of your service account to be used by Terraform
+    - Validate common org policies that might interfere with your deployment
 
     ```sh
     scripts/pre_tf_setup.sh
@@ -157,16 +178,16 @@ Once the workflow completes successfully, all documents will be imported into th
 
 ### Delete a document from DPU
 1. Identify the document you want to delete:
-    * Open Agent Builder Datastore and note down the ID and URI of the document that you want to delete from DP&U. 
+    * Open Agent Builder Datastore and note down the ID and URI of the document that you want to delete from DP&U.
     * Make sure the file in the URI exists in the Google Cloud Storage bucket
     * Please note that this script will not delete the GCS Folder that contains the file
     * Based on the URI, identify and note down the name of the BQ Table that contains the document meta-data
     * Please note that this script will not delete the BQ Table that contains the document meta-data
 
-1. Execute the bash script to delete a document:  
+1. Execute the bash script to delete a document:
 
     ```sh
     scripts/delete_doc.sh -d <DOC_ID> -u <DOC_URI> -t <BQ_TABLE> [-p <PROJECT_ID>]
-    ```    
+    ```
 
 For more information on the Web-UI component, please refer to its [README](./components/webui/README.md).

--- a/README.md
+++ b/README.md
@@ -25,13 +25,19 @@ The solution comprises the following key components:
 This guide provides step-by-step instructions on how to deploy the `Document Process and Understanding with Composer` sample on Google Cloud using Terraform.
 
 ### Prerequisites
-To deploy this example you need:
-- An account with the [Project Owner role](https://cloud.google.com/iam/docs/understanding-roles#resource-manager-roles) on the project. This grants the necessary permissions to create and manage resources.
-- An account with the [Organization Policy Admin](https://cloud.google.com/resource-manager/docs/organization-policy/creating-managing-policies) role assigned within the organization, which is required to modify the following organization policies:
+
+1. You have already completed [Create or select a Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects) and ensured that [billing is enabled for your Google Cloud project](https://cloud.google.com/billing/docs/how-to/verify-billing-enabled#console).
+
+1. This example code is deployed through terraform using the identity of a least privilege service account. To create this service account, your user identity must have [IAM Roles](https://cloud.google.com/iam/docs/roles-overview) on your project:
+    - Service Account Admin
+    - Project IAM Admin
+    - Service Usage Admin
+    - Organization Policy Viewer
+
+1. Validate whether the following Organization Policies are enforced on this project, which can conflict with deploying the web-UI interface.
     * `compute.vmExternalIpAccess`
     * `compute.requireShieldedVm`
     * `iam.allowedPolicyMemberDomains`
-
 
     These modifications enable public IP access for the Web-UI interface while securing it through Identity Aware Proxy (IAP). If policy adjustments are not possible, you can opt to exclude the Web-UI component during deployment by setting the Terraform variable `deploy_ui` to `false`. Alternatively, you can deploy the Web-UI locally by referring to the instructions in the [Deploy Locally](./components/webui/README.md#deploy-locally) section.
 
@@ -44,11 +50,6 @@ To deploy this example you need:
     1. [install Terraform](https://developer.hashicorp.com/terraform/tutorials/gcp-get-started/install-cli)
     1. [install the git CLI](https://github.com/git-guides/install-git)
     1. [set up application default credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
-
-1. [Create or select a Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
-
-1. Make sure that [billing is enabled for your Google Cloud project](https://cloud.google.com/billing/docs/how-to/verify-billing-enabled#console).
-
 
 1. Clone this repository
 

--- a/components/processing/form_parser/build/build_container_image.sh
+++ b/components/processing/form_parser/build/build_container_image.sh
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash  
+#!/bin/bash
 # Bash script
 
-if ! gcloud artifacts repositories describe dpu-form-parser-repo --location=$REGION; then 
+##TODO: has an underlying dependency on legacy Cloud Build SA, so most new environments will fall back to Compute default SA. I added roles to Compute Sdefault SA to avoid permissions errors, but it would be better to explicitly specify a builder SA and not rely on default Compute SA
+
+if ! gcloud artifacts repositories describe dpu-form-parser-repo --location=$REGION; then
     echo "repo not found"
     gcloud artifacts repositories create dpu-form-parser-repo --repository-format=docker --location=$REGION --description="repo build with cmd" --async
 else

--- a/sample-deployments/composer-orchestrated-process/project_apis.txt
+++ b/sample-deployments/composer-orchestrated-process/project_apis.txt
@@ -1,0 +1,6 @@
+cloudresourcemanager.googleapis.com
+serviceusage.googleapis.com
+iam.googleapis.com
+compute.googleapis.com
+orgpolicy.googleapis.com
+cloudbuild.googleapis.com

--- a/sample-deployments/composer-orchestrated-process/project_roles.txt
+++ b/sample-deployments/composer-orchestrated-process/project_roles.txt
@@ -8,7 +8,6 @@ roles/iam.serviceAccountAdmin
 roles/iam.serviceAccountUser
 roles/iap.admin
 roles/logging.configWriter
-roles/logging.logWriter
 roles/resourcemanager.projectIamAdmin
 roles/servicedirectory.admin
 roles/serviceusage.serviceUsageAdmin

--- a/sample-deployments/composer-orchestrated-process/project_roles.txt
+++ b/sample-deployments/composer-orchestrated-process/project_roles.txt
@@ -1,0 +1,15 @@
+roles/artifactregistry.createOnPushWriter
+roles/bigquery.dataOwner
+roles/composer.admin
+roles/compute.networkAdmin
+roles/compute.securityAdmin
+roles/container.clusterAdmin
+roles/iam.serviceAccountAdmin
+roles/iam.serviceAccountUser
+roles/iap.admin
+roles/logging.configWriter
+roles/logging.logWriter
+roles/resourcemanager.projectIamAdmin
+roles/servicedirectory.admin
+roles/serviceusage.serviceUsageAdmin
+roles/storage.admin

--- a/sample-deployments/composer-orchestrated-process/scripts/common.sh
+++ b/sample-deployments/composer-orchestrated-process/scripts/common.sh
@@ -27,12 +27,9 @@ DIVIDER=$(printf %"$(tput cols)"s | tr " " "*")
 DIVIDER+="\n"
 
 # DECLARE VARIABLES
-declare -a apis_array=("cloudresourcemanager.googleapis.com"
-                "serviceusage.googleapis.com"
-                "iam.googleapis.com"
-                "compute.googleapis.com"
-                "orgpolicy.googleapis.com"
-                )
+mapfile -t roles_array < project_apis.txt
+mapfile -t roles_array < project_roles.txt
+
 
 # DISPLAY HELPERS
 
@@ -85,7 +82,7 @@ check_environment_variable() {
 }
 
 # shell script function to check if api is enabled
-check_apis_enabled(){
+check_api_enabled(){
     local __api_endpoint=$1
     COUNTER=0
     MAX_TRIES=100
@@ -140,10 +137,10 @@ set_policy_rule(){
 }
 
 # shell script function to enable api
-enable_apis(){
+enable_api(){
     local __api_endpoint=$1
     gcloud services enable $__api_endpoint
-    check_apis_enabled $__api_endpoint
+    check_api_enabled $__api_endpoint
     unset __api_endpoint
 }
 
@@ -152,7 +149,27 @@ enable_all_apis () {
     ## now loop through the above array
     for i in "${apis_array[@]}"
     do
-        enable_apis "$i"
+      echo $i
+        enable_api "$i"
     done
+}
+
+# shell script function to enable IAM roles
+enable_role(){
+    local __role=$1
+    gcloud projects add-iam-policy-binding $PROJECT_ID --role=$1 --member=$__principal
+    unset __role
+}
+
+# enable all roles in the array
+enable_all_roles () {
+    local __principal=serviceAccount:$1
+    ## now loop through the above array
+    for i in "${roles_array[@]}"
+    do
+        echo $i
+        enable_role "$i" "serviceAccount:dpu-deployer@efe-dpu-08052024.iam.gserviceaccount.com"
+    done
+    unset __principal
 }
 

--- a/sample-deployments/composer-orchestrated-process/scripts/pre_tf_setup.sh
+++ b/sample-deployments/composer-orchestrated-process/scripts/pre_tf_setup.sh
@@ -36,18 +36,27 @@ section_open  "Setting the Google Cloud project to: ${PROJECT_ID}"
     gcloud config set project "${PROJECT_ID}"
 section_close
 
-section_open  "SDK login"
-    gcloud auth login --update-adc
-section_close
+#section_open  "SDK login for the user "
+#    gcloud auth login
+#    gcloud auth application-default login --impersonate-service-account=${SERVICE_ACCOUNT_ID}
+#section_close
 
-section_open "Enable all the required APIs"
+section_open "Enable the required APIs "
     enable_all_apis
 section_close
 
-section_open "Check and try to set required org-policies on project: ${PROJECT_ID}"
-    check_and_set_policy_rule "compute.vmExternalIpAccess" "allowAll: true" '"allowAll": true'  "${PROJECT_ID}"
-    check_and_set_policy_rule "compute.requireShieldedVm" "enforce: false" '"enforce": false' "${PROJECT_ID}"
-    check_and_set_policy_rule "iam.allowedPolicyMemberDomains" "allowAll: true" '"allowAll": true' "${PROJECT_ID}"
+section_open "Enable all the required IAM roles for deployer service account, serviceAccount:"${SERVICE_ACCOUNT_ID}""
+    enable_all_roles  "${SERVICE_ACCOUNT_ID}"
+section_close
+
+#section_open "Check and try to set required org-policies on project: ${PROJECT_ID}"
+#    check_and_set_policy_rule "compute.vmExternalIpAccess" "allowAll: true" '"allowAll": true'  "${PROJECT_ID}"
+#    check_and_set_policy_rule "compute.requireShieldedVm" "enforce: false" '"enforce": false' "${PROJECT_ID}"
+#    check_and_set_policy_rule "iam.allowedPolicyMemberDomains" "allowAll: true" '"allowAll": true' "${PROJECT_ID}"
+#section_close
+
+section_open  "Set Application Default Credentials to be used by Terraform"
+    gcloud auth application-default login --impersonate-service-account=${SERVICE_ACCOUNT_ID}
 section_close
 
 section_open "Build and push container image to Artifact Registry for Form Processor"

--- a/sample-deployments/composer-orchestrated-process/scripts/pre_tf_setup.sh
+++ b/sample-deployments/composer-orchestrated-process/scripts/pre_tf_setup.sh
@@ -46,19 +46,25 @@ section_open "Enable the required APIs "
 section_close
 
 section_open "Enable all the required IAM roles for deployer service account, serviceAccount:"${SERVICE_ACCOUNT_ID}""
-    enable_all_roles  "${SERVICE_ACCOUNT_ID}"
+    enable_deployer_roles  "${SERVICE_ACCOUNT_ID}"
 section_close
 
+section_open "Explicitly declare underlying permissions for Cloud Build processes"
+    enable_builder_roles
+section_close
+
+##TODO:need to use policy analyzer to check effective policy. Can't assume the user always wants to remove the constraint.
 #section_open "Check and try to set required org-policies on project: ${PROJECT_ID}"
-#    check_and_set_policy_rule "compute.vmExternalIpAccess" "allowAll: true" '"allowAll": true'  "${PROJECT_ID}"
-#    check_and_set_policy_rule "compute.requireShieldedVm" "enforce: false" '"enforce": false' "${PROJECT_ID}"
-#    check_and_set_policy_rule "iam.allowedPolicyMemberDomains" "allowAll: true" '"allowAll": true' "${PROJECT_ID}"
+    check_and_set_policy_rule "compute.vmExternalIpAccess" "allowAll: true" '"allowAll": true'  "${PROJECT_ID}"
+    check_and_set_policy_rule "compute.requireShieldedVm" "enforce: false" '"enforce": false' "${PROJECT_ID}"
+    check_and_set_policy_rule "iam.allowedPolicyMemberDomains" "allowAll: true" '"allowAll": true' "${PROJECT_ID}"
 #section_close
 
 section_open  "Set Application Default Credentials to be used by Terraform"
     gcloud auth application-default login --impersonate-service-account=${SERVICE_ACCOUNT_ID}
 section_close
 
+##TODO: build is done in global region, does not respect the specified region
 section_open "Build and push container image to Artifact Registry for Form Processor"
     ../../components/processing/form_parser/build/build_container_image.sh
 section_close


### PR DESCRIPTION
- Define minimum IAM roles for the deployer service account
- Add minimum IAM role enablement to service account and set ADC using service account, in the setup script
- Improve visibility of how we show which APIs and Roles are required (so that somebody with a different management method can easily identify and adopt it)
- Improve logic for how we validate org policies 
- Fix permissions issue with underlying Cloud Build