### PR TITLE
Cleaned up config managment so that file supported is configured once in the DAG, and passed to the processing job

### DIFF
--- a/components/dpu-workflow/src/docs_processing_orchestrator.py
+++ b/components/dpu-workflow/src/docs_processing_orchestrator.py
@@ -160,10 +160,14 @@ def generate_process_job_params(**context):
     bq_table = context["ti"].xcom_pull(key="bigquery_table")
     doc_processor_job_name = os.environ.get("DOC_PROCESSOR_JOB_NAME")
     gcs_reject_bucket = os.environ.get("DPU_REJECT_BUCKET")
-
-    process_job_params = cloud_run_utils.get_process_job_params(bq_table,
-                                                doc_processor_job_name,
-                                                gcs_reject_bucket, mv_params)
+    supported_files = {x["file-suffix"]: x["processor"] for x in context[
+        "params"]["supported_files"]}
+    process_job_params = cloud_run_utils.get_process_job_params(
+        bq_table,
+        doc_processor_job_name,
+        gcs_reject_bucket, 
+        mv_params, 
+        supported_files)
     return process_job_params
 
 def generate_output_table_name(**context):
@@ -203,14 +207,14 @@ with (DAG(
         "input_folder": "",
         "supported_files": Param(
             [
-                {"file-suffix": "pdf", "processor": "agent-builder"},
-                {"file-suffix": "docx", "processor": "agent-builder"},
-                {"file-suffix": "txt", "processor": "agent-builder"},
-                {"file-suffix": "html", "processor": "agent-builder"},
-                {"file-suffix": "msg", "processor": "dpu-doc-processor"},
-                {"file-suffix": "zip", "processor": "dpu-doc-processor"},
-                {"file-suffix": "xlsx", "processor": "dpu-doc-processor"},
-                {"file-suffix": "xlsm", "processor": "dpu-doc-processor"},
+                {"file-suffix": "pdf", "processor": "txt-processor"},
+                {"file-suffix": "docx", "processor": "txt-processor"},
+                {"file-suffix": "txt", "processor": "txt-processor"},
+                {"file-suffix": "html", "processor": "txt-processor"},
+                {"file-suffix": "msg", "processor": "msg-processor"},
+                {"file-suffix": "zip", "processor": "zip-processor"},
+                {"file-suffix": "xlsx", "processor": "xlsx-processor"},
+                {"file-suffix": "xlsm", "processor": "xlsx-processor"},
             ],
             type="array",
             items={

--- a/components/dpu-workflow/src/utils/cloud_run_utils.py
+++ b/components/dpu-workflow/src/utils/cloud_run_utils.py
@@ -15,6 +15,7 @@
 import logging
 import os
 from enum import Enum
+from typing import Dict
 
 from google.cloud import storage, documentai
 
@@ -27,8 +28,10 @@ class FolderNames(str, Enum):
 
 
 def get_process_job_params(bq_table, doc_processor_job_name, gcs_reject_bucket,
-                           mv_params):
+                           mv_params, supported_files: Dict[str, str]):
     process_job_params = []
+    supported_files_args = [f"--file-type={k}:{v}" for k,
+                            v in supported_files.items()]
     for mv_obj in mv_params:
         dest = (f"gs://{mv_obj['destination_bucket']}/"
                 f"{mv_obj['destination_object']}")
@@ -36,18 +39,20 @@ def get_process_job_params(bq_table, doc_processor_job_name, gcs_reject_bucket,
                        f"{mv_obj['destination_object']}")
         bq_id = (f"{bq_table['project_id']}.{bq_table['dataset_id']}."
                  f"{bq_table['table_id']}")
+        args = [
+            dest,
+            reject_dest,
+            "--write_json=False",
+            f"--write_bigquery={bq_id}",
+        ]
+        args.extend(supported_files_args)
         job_param = {
             "overrides": {
                 "container_overrides": [
                     {
                         "name":       f"{doc_processor_job_name}",
-                        "args":       [
-                            dest,
-                            reject_dest,
-                            "--write_json=False",
-                            f"--write_bigquery={bq_id}",
-                        ],
-                        "clear_args": False,
+                        "args":       args,
+                        "clear_args": False
                     }
                 ],
                 "task_count":          1,

--- a/components/processing/libs/processor-msg/src/processors/msg/main_processor.py
+++ b/components/processing/libs/processor-msg/src/processors/msg/main_processor.py
@@ -172,7 +172,7 @@ def process_recursive(
 
     # Return with the children
     for child in list(output.list()):
-        results.extend(process_recursive(child, reject_dir))
+        results.extend(process_recursive(child, reject_dir, supported_files))
 
     return results
 

--- a/components/processing/libs/processor-msg/src/processors/msg/main_processor.py
+++ b/components/processing/libs/processor-msg/src/processors/msg/main_processor.py
@@ -15,6 +15,10 @@
 
 import logging
 import json
+import os
+import sys
+from enum import Enum
+
 from processors.msg.msg_processor import msg_processor
 from processors.xlsx import xlsx_processor
 from processors.zip.unzip_processor import unzip_processor
@@ -26,20 +30,25 @@ from typing import Dict, Optional, Callable
 logger = logging.getLogger(__name__)
 
 
-def find_processor(source: GCSPath) -> Optional[Callable[[GCSPath, GCSPath], Dict]]:
-    if source.suffix == ".msg":
-        return msg_processor
-    elif source.suffix == ".zip":
-        return unzip_processor
-    elif source.suffix in (".xlsx", ".xlsm"):
-        return xlsx_processor
+class Processors(str, Enum):
+    TXT = "txt-processor"
+    MSG = "msg-processor"
+    ZIP = "zip-processor"
+    XLSX = "xlsx-processor"
 
-    return None
+
+PROCESSOR_NAMES_TO_CALLABLE = {
+    Processors.TXT.value: None, # Special case - handled inline within code
+    Processors.MSG.value: msg_processor,
+    Processors.ZIP.value: unzip_processor,
+    Processors.XLSX.value: xlsx_processor,
+}
 
 
 def process_all_objects(
     source_dir: GCSPath,
     reject_dir: GCSPath,
+    supported_files: Dict[str, str],
     write_json=True,
     write_bigquery: str = "",
 ):
@@ -53,6 +62,7 @@ def process_all_objects(
         process_object(
             obj,
             reject_dir,
+            supported_files,
             write_json=write_json,
             bq_writer=writer,
         )
@@ -86,6 +96,7 @@ def reject_oversized_file(
 def process_recursive(
     source: GCSPath,
     reject_dir: GCSPath,
+    supported_files: Dict[str, str],
 ) -> list[dict]:
 
     result = {
@@ -97,7 +108,14 @@ def process_recursive(
     }
     results = [result]
 
-    if source.suffix in (".txt", ".html", ".pdf", ".docx"):
+    if not supported_files.get(source.suffix, False):
+        result['status'] = 'Not indexed or expanded'
+        result['metadata']['reason'] = (f"file of type {source.suffix} not "
+                                        f"supported")
+        return results
+    processor_name = supported_files[source.suffix]
+
+    if processor_name == Processors.TXT.value:
 
         # current file size limit of 100MB in Data Store
         if reject_oversized_file(source, reject_dir, 100):
@@ -113,10 +131,15 @@ def process_recursive(
         result['status'] = 'Indexed'
         return results
 
-    # Find processor, if any, for generating outputs for this object
-    processor = find_processor(source)
-    if not processor:
+    # the one special case is txt-processor, that will return None, but this
+    # should have been handled above - beware of changes to the order of
+    # operations here.
+    processor = PROCESSOR_NAMES_TO_CALLABLE.get(processor_name)
+    if processor is None:
         result['status'] = 'Not indexed or expanded'
+        result['metadata']['reason'] = (f"file type {source.suffix} is mapped "
+                                        f"to a processor {processor_name} that "
+                                        f"is not mapped to a callable")
         return results
 
     # Attempt to use it.
@@ -157,6 +180,7 @@ def process_recursive(
 def process_object(
     source: GCSPath,
     reject_dir: GCSPath,
+    supported_files: Dict[str, str],
     write_json=True,
     bq_writer: Optional[BigQueryWriter] = None,
 ):
@@ -164,7 +188,7 @@ def process_object(
     logger.info(f'Processing {source}...')
 
     # Extract everything
-    objs = process_recursive(source, reject_dir)
+    objs = process_recursive(source, reject_dir, supported_files)
 
     logger.debug(f'Objects: {objs}')
 

--- a/components/processing/libs/processor-msg/src/processors/msg/run.py
+++ b/components/processing/libs/processor-msg/src/processors/msg/run.py
@@ -17,7 +17,25 @@ import argparse
 import logging
 
 from processors.base.gcsio import GCSPath
-from processors.msg.main_processor import process_all_objects
+from processors.msg.main_processor import process_all_objects, Processors
+
+# Specialized action to parse multiple key-value pairs into a dict
+class keyvalue(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string = None, 
+                 *args, **kwargs):
+        # if this is the first time we call this, we need to make sure that 
+        # the namespace contains a dict for our `dest`
+        if (not hasattr(namespace, self.dest) or not 
+            getattr(namespace, self.dest)):
+            setattr(namespace, self.dest, dict())
+        
+        # for each key-value pair, parse the key-value (seperated by an equal
+        # sign), validate the key (starts with a dot) and store in the dict
+        for value in values:
+            key, value = list(map(lambda x: x.strip(), value.split(":")))
+            if not key.startswith("."):
+                key = "." + key
+            getattr(namespace, self.dest)[key] = value
 
 
 def main() -> None:
@@ -42,6 +60,17 @@ def main() -> None:
         default="",
         help="BigQuery fully qualified table to write results",
     )
+    all_processors = ", ".join([x.value for x in Processors])
+    parser.add_argument("--file-type", 
+                        metavar="KEY:VALUE",
+                        dest="supported_files",
+                        help="Set all supported file types in the form of "
+                             "FILE_TYPE:PROCESSOR. Minimum one is required. "
+                             "Multiple entries are possible. Supported "
+                             f"processors are {all_processors}",
+                        nargs="+",
+                        required=True,
+                        action=keyvalue)
 
     args = parser.parse_args()
 
@@ -51,6 +80,7 @@ def main() -> None:
     process_all_objects(
         GCSPath(args.process_dir),
         GCSPath(args.reject_dir),
+        args.supported_files,    
         write_json=args.write_json,
         write_bigquery=args.write_bigquery,
     )

--- a/sample-deployments/composer-orchestrated-process/scripts/trigger_workflow.sh
+++ b/sample-deployments/composer-orchestrated-process/scripts/trigger_workflow.sh
@@ -26,35 +26,35 @@ function trigger_dag() {
     "supported_files": [
         {
             "file-suffix": "pdf",
-            "processor": "agent-builder"
+            "processor": "txt-processor"
         },
         {
             "file-suffix": "txt",
-            "processor": "agent-builder"
+            "processor": "txt-processor"
         },
         {
             "file-suffix": "html",
-            "processor": "agent-builder"
+            "processor": "txt-processor"
         },
         {
             "file-suffix": "msg",
-            "processor": "dpu-doc-processor"
+            "processor": "msg-processor"
         },
         {
             "file-suffix": "zip",
-            "processor": "dpu-doc-processor"
+            "processor": "zip-processor"
         },
         {
             "file-suffix": "xlsx",
-            "processor": "dpu-doc-processor"
+            "processor": "xlsx-processor"
         },
         {
             "file-suffix": "xlsm",
-            "processor": "dpu-doc-processor"
+            "processor": "xlsx-processor"
         },
         {
             "file-suffix": "docx",
-            "processor": "dpu-doc-processor"
+            "processor": "txt-processor"
         }
     ],
     "classifier": {


### PR DESCRIPTION
This PR is to remove the duplicate configurations of file types supported in each run. With this PR, file type configurations are given once for every DAG run, and are passed to the doc-processing Cloud Run Job. The configuration has the same structure (objects with `file-suffix` and `processor` keys), but the permitted values for the processors are different - since they map to different doc-processing operations (txt-processor, msg-processor, zip-processor and xlsx-processor)

- In the Processing CRJ, supported files is now given as an argument and are mapped to specific operations in the processing-msg job
- Argument is given as a CLI argument, and is required
- Special argparse.Action was implemented to parse key:value pairs into a dict
- DAG was adapted to pass in argument to the CRJ

Important Note: This means the permitted values in the DAG config are the same structure, but support different values, that are actually being passed ot the CRJ.