### PR TITLE
terraform provsioning of tf-remote-state resouces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ local_dev/**
 **/terraform.tfstate*
 **/terraform.tfvars
 **/.terraform.tfstate*
+**/backend.tf
 **/.terraform/**
 **/.terraform.lock.hcl
 dp.md

--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ To deploy this solution, perform the follow steps:
     ```
     The provisioning process may take about 30 minutes to complete.
 
+1. Migrate Terraform state to the remote Cloud Storage backend:
+    ```sh
+    terraform init -migrate-state
+    ```
+    Terraform detects that you already have a state file locally and prompts you to migrate the state to the new Cloud Storage bucket. When prompted, enter `yes`.
+
 ### Update your environment with new code/new version
 
 If you update the source code or pull the latest changes from the repository, re-run the following command to apply the changes to your deployed environment:

--- a/sample-deployments/composer-orchestrated-process/remote-backend.tf
+++ b/sample-deployments/composer-orchestrated-process/remote-backend.tf
@@ -1,0 +1,39 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_storage_bucket" "tf_backend" {
+  name     = "${var.project_id}-eks-tf-backend"
+  location = var.region
+
+  force_destroy               = false
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "local_file" "remote_backend" {
+  file_permission = "0644"
+  filename        = "${path.module}/backend.tf"
+
+  content = <<-EOT
+  terraform {
+    backend "gcs" {
+      bucket = "${google_storage_bucket.tf_backend.name}"
+    }
+  }
+  EOT
+}


### PR DESCRIPTION
- create remote gcs bucket for tf state 
- create local backend.tf file pointing to the gcs bucket
- updated the deployment instruction on how to move the local state to the remote state