### PR TITLE
feat: Data store layout parser

### DIFF
--- a/components/common-infra/terraform/bigquery.tf
+++ b/components/common-infra/terraform/bigquery.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module "docs_store_dataset" {
-  source         = "github.com/terraform-google-modules/terraform-google-bigquery?ref=b349bf87446f478c54604a79f1a88145d5cea36f" # commit hash of version 8.1.0
+  source         = "github.com/terraform-google-modules/terraform-google-bigquery?ref=0fe8ab60d7291a2260cd460d55cdcca7fc815a0d" # commit hash of version 8.1.0
   dataset_id     = var.bq_store_dataset
   dataset_name   = var.bq_store_dataset
   project_id     = module.project_services.project_id

--- a/components/common-infra/terraform/gcs.tf
+++ b/components/common-infra/terraform/gcs.tf
@@ -11,9 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+locals {
+  simple_bucket_commit_hash = "e8bb6eb49fdaf5f6f300d1b6dc46f097173dc488" # version 6.1.0, this commit is needed where kms is upgraded to 3.0, otherwise will get version conflict for google provider
+}
 
 module "input_bucket" {
-  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=c86102c9b34e4a2e3cd37e40b687770990446679" # commit hash of version 6.1.0
+  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=${local.simple_bucket_commit_hash}"
   project_id               = module.project_services.project_id
   name                     = "docs-input-${var.project_id}"
   location                 = var.region
@@ -23,7 +26,7 @@ module "input_bucket" {
 }
 
 module "process_bucket" {
-  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=c86102c9b34e4a2e3cd37e40b687770990446679" # commit hash of version 6.1.0
+  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=${local.simple_bucket_commit_hash}"
   project_id               = module.project_services.project_id
   name                     = "dpu-process-${var.project_id}"
   location                 = var.region
@@ -33,7 +36,7 @@ module "process_bucket" {
 }
 
 module "reject_bucket" {
-  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=c86102c9b34e4a2e3cd37e40b687770990446679" # commit hash of version 6.1.0
+  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=${local.simple_bucket_commit_hash}"
   project_id               = module.project_services.project_id
   name                     = "dpu-reject-${var.project_id}"
   location                 = var.region

--- a/components/common-infra/terraform/gcs.tf
+++ b/components/common-infra/terraform/gcs.tf
@@ -11,12 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-locals {
-  simple_bucket_commit_hash = "e8bb6eb49fdaf5f6f300d1b6dc46f097173dc488" # version 6.1.0, this commit is needed where kms is upgraded to 3.0, otherwise will get version conflict for google provider
-}
 
 module "input_bucket" {
-  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=${local.simple_bucket_commit_hash}"
+  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=e8bb6eb49fdaf5f6f300d1b6dc46f097173dc488" # version 6.1.0, this commit is needed where kms is upgraded to 3.0, otherwise will get version conflict for google provider
   project_id               = module.project_services.project_id
   name                     = "docs-input-${var.project_id}"
   location                 = var.region
@@ -26,7 +23,7 @@ module "input_bucket" {
 }
 
 module "process_bucket" {
-  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=${local.simple_bucket_commit_hash}"
+  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=e8bb6eb49fdaf5f6f300d1b6dc46f097173dc488" # version 6.1.0, this commit is needed where kms is upgraded to 3.0, otherwise will get version conflict for google provider
   project_id               = module.project_services.project_id
   name                     = "dpu-process-${var.project_id}"
   location                 = var.region
@@ -36,7 +33,7 @@ module "process_bucket" {
 }
 
 module "reject_bucket" {
-  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=${local.simple_bucket_commit_hash}"
+  source                   = "github.com/terraform-google-modules/terraform-google-cloud-storage.git//modules/simple_bucket?ref=e8bb6eb49fdaf5f6f300d1b6dc46f097173dc488" # version 6.1.0, this commit is needed where kms is upgraded to 3.0, otherwise will get version conflict for google provider
   project_id               = module.project_services.project_id
   name                     = "dpu-reject-${var.project_id}"
   location                 = var.region

--- a/components/webui/terraform/cloudrun.tf
+++ b/components/webui/terraform/cloudrun.tf
@@ -94,8 +94,7 @@ resource "google_compute_region_network_endpoint_group" "eks_webui_neg" {
 }
 
 module "eks_webui_lb" {
-  source                          = "terraform-google-modules/lb-http/google//modules/serverless_negs" #checkov:skip=CKV_TF_1:Commit hash cannot be used for sub-module
-  version                         = "~> 11.0"
+  source                          = "github.com/terraform-google-modules/terraform-google-lb-http.git//modules/serverless_negs?ref=99d56bea9a7f561102d2e449852eaf725e8b8d0c" # version 12.0.0
   name                            = "eks-webui-lb"
   project                         = var.project_id
   managed_ssl_certificate_domains = var.lb_ssl_certificate_domains

--- a/sample-deployments/composer-orchestrated-process/main.tf
+++ b/sample-deployments/composer-orchestrated-process/main.tf
@@ -94,9 +94,9 @@ resource "google_discovery_engine_search_engine" "basic" {
 }
 
 module "processor" {
-  source     = "../../components/processing/terraform"
-  project_id = var.project_id
-  region     = var.region
+  source                            = "../../components/processing/terraform"
+  project_id                        = var.project_id
+  region                            = var.region
   repository_region                 = var.region
   artifact_repo                     = module.common_infra.artifact_repo.name
   cloud_build_service_account_email = module.common_infra.cloud_build_service_account.email

--- a/sample-deployments/composer-orchestrated-process/main.tf
+++ b/sample-deployments/composer-orchestrated-process/main.tf
@@ -58,22 +58,6 @@ resource "google_discovery_engine_data_store" "dpu_ds" {
   create_advanced_site_search = false
   document_processing_config {
     default_parsing_config {
-      digital_parsing_config {}
-    }
-    parsing_config_overrides {
-      file_type = "pdf"
-      layout_parsing_config {}
-    }
-    parsing_config_overrides {
-      file_type = "docx"
-      layout_parsing_config {}
-    }
-    parsing_config_overrides {
-      file_type = "pptx"
-      layout_parsing_config {}
-    }
-    parsing_config_overrides {
-      file_type = "xlsx"
       layout_parsing_config {}
     }
   }

--- a/sample-deployments/composer-orchestrated-process/main.tf
+++ b/sample-deployments/composer-orchestrated-process/main.tf
@@ -56,6 +56,27 @@ resource "google_discovery_engine_data_store" "dpu_ds" {
   content_config              = "CONTENT_REQUIRED"
   solution_types              = ["SOLUTION_TYPE_SEARCH"]
   create_advanced_site_search = false
+  document_processing_config {
+    default_parsing_config {
+      digital_parsing_config {}
+    }
+    parsing_config_overrides {
+      file_type = "pdf"
+      layout_parsing_config {}
+    }
+    parsing_config_overrides {
+      file_type = "docx"
+      layout_parsing_config {}
+    }
+    parsing_config_overrides {
+      file_type = "pptx"
+      layout_parsing_config {}
+    }
+    parsing_config_overrides {
+      file_type = "xlsx"
+      layout_parsing_config {}
+    }
+  }
 }
 
 resource "google_discovery_engine_search_engine" "basic" {
@@ -76,8 +97,6 @@ module "processor" {
   source     = "../../components/processing/terraform"
   project_id = var.project_id
   region     = var.region
-  # bq_region                         = var.region
-  # gcs_region                        = var.region
   repository_region                 = var.region
   artifact_repo                     = module.common_infra.artifact_repo.name
   cloud_build_service_account_email = module.common_infra.cloud_build_service_account.email

--- a/sample-deployments/composer-orchestrated-process/scripts/pre_tf_setup.sh
+++ b/sample-deployments/composer-orchestrated-process/scripts/pre_tf_setup.sh
@@ -55,7 +55,7 @@ enable_builder_roles
 section_close
 
 section_open "Set Application Default Credentials to be used by Terraform"
-yes | gcloud auth application-default login --impersonate-service-account="${SERVICE_ACCOUNT_ID}"
+gcloud auth application-default login --impersonate-service-account="${SERVICE_ACCOUNT_ID}"
 section_close
 
 section_open "Build and push container image to Artifact Registry for Form Processor"


### PR DESCRIPTION
- default to layout parser for `pdf`, `docx`,`pptx`,`xlsx` file in agent builder data store
- needed to upgrade some resource so that terraform google-provider 6.6.0 can be user, where support for layout parser is 