### PR TITLE
fix: Security Command Center SHA vulnerabilities 

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -46,15 +46,15 @@ steps:
       - "WEB_UI_DOMAINS=${_WEB_UI_DOMAINS}"
       - "GCLOUD_TF_DOWNLOAD=never"
 
-#  - id: cleanup
-#    name: "${_BUILDER_IMAGE_NAME}:${_BUILDER_IMAGE_TAG}"
-#    args:
-#      - "-x"
-#      - "-c"
-#      - >-
-#        gcloud config unset auth/impersonate_service_account;
-#        gcloud projects delete ${_TEST_PROJECT_ID} --quiet
-#    entrypoint: /bin/bash
+  - id: cleanup
+    name: "${_BUILDER_IMAGE_NAME}:${_BUILDER_IMAGE_TAG}"
+    args:
+      - "-x"
+      - "-c"
+      - >-
+        gcloud config unset auth/impersonate_service_account;
+        gcloud projects delete ${_TEST_PROJECT_ID} --quiet
+    entrypoint: /bin/bash
 
 tags:
   - "ci"

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -46,15 +46,15 @@ steps:
       - "WEB_UI_DOMAINS=${_WEB_UI_DOMAINS}"
       - "GCLOUD_TF_DOWNLOAD=never"
 
-  - id: cleanup
-    name: "${_BUILDER_IMAGE_NAME}:${_BUILDER_IMAGE_TAG}"
-    args:
-      - "-x"
-      - "-c"
-      - >-
-        gcloud config unset auth/impersonate_service_account;
-        gcloud projects delete ${_TEST_PROJECT_ID} --quiet
-    entrypoint: /bin/bash
+#  - id: cleanup
+#    name: "${_BUILDER_IMAGE_NAME}:${_BUILDER_IMAGE_TAG}"
+#    args:
+#      - "-x"
+#      - "-c"
+#      - >-
+#        gcloud config unset auth/impersonate_service_account;
+#        gcloud projects delete ${_TEST_PROJECT_ID} --quiet
+#    entrypoint: /bin/bash
 
 tags:
   - "ci"

--- a/components/common-infra/terraform/main.tf
+++ b/components/common-infra/terraform/main.tf
@@ -28,6 +28,7 @@ module "project_services" {
     "bigquery.googleapis.com",
     "alloydb.googleapis.com",
     "servicenetworking.googleapis.com",
+    "dns.googleapis.com"
   ]
 }
 

--- a/components/common-infra/terraform/variables.tf
+++ b/components/common-infra/terraform/variables.tf
@@ -50,3 +50,12 @@ variable "alloy_db_cluster_id" {
   type        = string
   default     = "eks-docs-results"
 }
+
+variable "composer_cidr" {
+  description = "CIDR ranges for configuring Cloud Composer"
+  type = object({
+    primary                  = string
+    cluster_secondary_range  = string
+    services_secondary_range = string
+  })
+}

--- a/components/common-infra/terraform/variables.tf
+++ b/components/common-infra/terraform/variables.tf
@@ -54,8 +54,10 @@ variable "alloy_db_cluster_id" {
 variable "composer_cidr" {
   description = "CIDR ranges for configuring Cloud Composer"
   type = object({
-    primary                  = string
+    subnet_primary           = string
     cluster_secondary_range  = string
     services_secondary_range = string
+    control_plane            = string
+    sql                      = string
   })
 }

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -22,3 +22,13 @@ module "vpc" {
   subnets = []
 
 }
+
+resource "google_dns_policy" "dns-policy" {
+  name           = "dns-policy"
+  enable_logging = true
+
+  networks {
+    network_url = module.vpc[0].network_id
+  }
+}
+

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -80,11 +80,11 @@ resource "google_compute_network_firewall_policy_rule" "default-deny-egress" {
   }
 }
 
-module "dns-private-zone" {
+module "dns-private-zone-googleapis" {
   source     = "github.com/terraform-google-modules/terraform-google-cloud-dns?ref=92bd8140d059388c6c22742ffcb5f4ab2c24cee9" #commit hash of version 5.3.0
   project_id = var.project_id
   type       = "private"
-  name       = "googleapis"
+  name       = "googleapis-com"
   domain     = "googleapis.com."
 
   private_visibility_config_networks = [module.vpc[0].network_self_link]
@@ -98,6 +98,90 @@ module "dns-private-zone" {
         "199.36.153.4", "199.36.153.5", "199.36.153.6", "199.36.153.7",
       ]
     },
+    {
+      name = "*"
+      type = "CNAME"
+      ttl  = 300
+      records = [
+        "restricted.googleapis.com.",
+      ]
+    },
+  ]
+}
+
+module "dns-private-zone-composer1" {
+  source     = "github.com/terraform-google-modules/terraform-google-cloud-dns?ref=92bd8140d059388c6c22742ffcb5f4ab2c24cee9" #commit hash of version 5.3.0
+  project_id = var.project_id
+  type       = "private"
+  name       = "composer-cloud-google-com"
+  domain     = "composer.cloud.google.com."
+
+  private_visibility_config_networks = [module.vpc[0].network_self_link]
+
+  recordsets = [
+    {
+      name = "*"
+      type = "CNAME"
+      ttl  = 300
+      records = [
+        "restricted.googleapis.com.",
+      ]
+    },
+  ]
+}
+
+module "dns-private-zone-composer2" {
+  source     = "github.com/terraform-google-modules/terraform-google-cloud-dns?ref=92bd8140d059388c6c22742ffcb5f4ab2c24cee9" #commit hash of version 5.3.0
+  project_id = var.project_id
+  type       = "private"
+  name       = "composer-googleusercontent-com"
+  domain     = "composer.googleusercontent.com."
+
+  private_visibility_config_networks = [module.vpc[0].network_self_link]
+
+  recordsets = [
+    {
+      name = "*"
+      type = "CNAME"
+      ttl  = 300
+      records = [
+        "restricted.googleapis.com.",
+      ]
+    },
+  ]
+}
+
+module "dns-private-zone-pkg-dev" {
+  source     = "github.com/terraform-google-modules/terraform-google-cloud-dns?ref=92bd8140d059388c6c22742ffcb5f4ab2c24cee9" #commit hash of version 5.3.0
+  project_id = var.project_id
+  type       = "private"
+  name       = "pkg-dev"
+  domain     = "pkg.dev."
+
+  private_visibility_config_networks = [module.vpc[0].network_self_link]
+
+  recordsets = [
+    {
+      name = "*"
+      type = "CNAME"
+      ttl  = 300
+      records = [
+        "restricted.googleapis.com.",
+      ]
+    },
+  ]
+}
+
+module "dns-private-zone-gcr-io" {
+  source     = "github.com/terraform-google-modules/terraform-google-cloud-dns?ref=92bd8140d059388c6c22742ffcb5f4ab2c24cee9" #commit hash of version 5.3.0
+  project_id = var.project_id
+  type       = "private"
+  name       = "gcr-io"
+  domain     = "gcr.io."
+
+  private_visibility_config_networks = [module.vpc[0].network_self_link]
+
+  recordsets = [
     {
       name = "*"
       type = "CNAME"

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -38,7 +38,7 @@ module "network_firewall_policy" {
   project_id  = var.project_id
   policy_name = "firewall-policy"
   description = "firewall policy to enable EKS functionality"
-  target_vpcs = [module.vpc[0].network_self_link]
+  target_vpcs = [module.vpc[0].network_id]
 
   rules = [
     {

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -63,8 +63,62 @@ resource "google_compute_network_firewall_policy_rule" "allow-google-apis" {
   }
 }
 
+resource "google_compute_network_firewall_policy_rule" "allow-subnet-internal" {
+  description     = "Allow internal traffic within the composer subnet"
+  action          = "allow"
+  direction       = "EGRESS"
+  enable_logging  = true
+  firewall_policy = google_compute_network_firewall_policy.policy.name
+  priority        = 1001
+  rule_name       = "allow-subnet-internal"
+
+  match {
+    dest_ip_ranges = [var.composer_cidr.primary]
+    layer4_configs {
+      ip_protocol = "tcp,udp"
+      ports       = ["all"]
+    }
+  }
+}
+
+resource "google_compute_network_firewall_policy_rule" "allow-composer-cluster-secondary-range" {
+  description     = "Allow internal traffic to reach Composer's cluster pods on the secondary subnet range"
+  action          = "allow"
+  direction       = "EGRESS"
+  enable_logging  = true
+  firewall_policy = google_compute_network_firewall_policy.policy.name
+  priority        = 1002
+  rule_name       = "allow-composer-cluster-secondary-range"
+
+  match {
+    dest_ip_ranges = [var.composer_cidr.cluster_secondary_range]
+    layer4_configs {
+      ip_protocol = "tcp,udp"
+      ports       = ["all"]
+    }
+  }
+}
+
+resource "google_compute_network_firewall_policy_rule" "allow-composer-services-secondary-range" {
+  description     = "Allow internal traffic to reach Composer's cluster pods on the secondary subnet range"
+  action          = "allow"
+  direction       = "EGRESS"
+  enable_logging  = true
+  firewall_policy = google_compute_network_firewall_policy.policy.name
+  priority        = 1003
+  rule_name       = "allow-composer-services-secondary-range"
+
+  match {
+    dest_ip_ranges = [var.composer_cidr.services_secondary_range]
+    layer4_configs {
+      ip_protocol = "tcp,udp"
+      ports       = ["all"]
+    }
+  }
+}
+
 resource "google_compute_network_firewall_policy_rule" "default-deny-egress" {
-  description     = "Allow private HTTPS access to google apis on the restricted VIP"
+  description     = "Catch-all deny egress rule to block traffic that has not been explicitly allowed"
   action          = "deny"
   direction       = "EGRESS"
   enable_logging  = true
@@ -79,6 +133,8 @@ resource "google_compute_network_firewall_policy_rule" "default-deny-egress" {
     }
   }
 }
+
+
 
 module "dns-private-zone-googleapis" {
   source     = "github.com/terraform-google-modules/terraform-google-cloud-dns?ref=92bd8140d059388c6c22742ffcb5f4ab2c24cee9" #commit hash of version 5.3.0

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -39,6 +39,12 @@ resource "google_compute_network_firewall_policy" "policy" {
   description = "firewall policy to enable EKS functionality"
 }
 
+resource "google_compute_network_firewall_policy_association" "primary" {
+  name              = "association"
+  attachment_target = module.vpc[0].network_id
+  firewall_policy   = google_compute_network_firewall_policy.policy.name
+}
+
 resource "google_compute_network_firewall_policy_rule" "allow-google-apis" {
   description     = "Allow private HTTPS access to google apis on the restricted VIP"
   action          = "allow"

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -76,16 +76,16 @@ resource "google_compute_network_firewall_policy_rule" "default-deny-egress" {
 
 module "dns-private-zone" {
   source     = "github.com/terraform-google-modules/terraform-google-cloud-dns?ref=92bd8140d059388c6c22742ffcb5f4ab2c24cee9" #commit hash of version 5.3.0
-  project_id = "var.project_id"
+  project_id = var.project_id
   type       = "private"
-  name       = "googleapis.com"
+  name       = "googleapis"
   domain     = "googleapis.com."
 
   private_visibility_config_networks = [module.vpc[0].network_self_link]
 
   recordsets = [
     {
-      name = "restricted.googleapis.com."
+      name = "restricted"
       type = "A"
       ttl  = 300
       records = [
@@ -93,11 +93,11 @@ module "dns-private-zone" {
       ]
     },
     {
-      name = "*.googleapis.com."
+      name = "*"
       type = "CNAME"
       ttl  = 300
       records = [
-        "restricted.googleapis.com",
+        "restricted.googleapis.com.",
       ]
     },
   ]

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -131,58 +131,6 @@ resource "google_compute_network_firewall_policy_rule" "allow-composer-control-p
   }
 }
 
-#resource "google_compute_network_firewall_policy_rule" "allow-composer-sql" {
-#  description     = "Allow internal traffic to reach the sql in tenant project"
-#  action          = "allow"
-#  direction       = "EGRESS"
-#  enable_logging  = true
-#  firewall_policy = google_compute_network_firewall_policy.policy.name
-#  priority        = 1005
-#  rule_name       = "allow-composer-sql"
-
-#  match {
-#    dest_ip_ranges = [var.composer_cidr.sql]
-#    layer4_configs {
-#    ip_protocol = "all"
-#   }
-#  }
-#}
-
-#resource "google_compute_network_firewall_policy_rule" "default-deny-egress-logger" {
-#  description     = "Logger"
-#  action          = "allow"
-#  direction       = "EGRESS"
-#  enable_logging  = true
-#  firewall_policy = google_compute_network_firewall_policy.policy.name
-#  priority        = 65529
-#  rule_name       = "default-deny-egress-logger"
-
-#  match {
-##    dest_ip_ranges = ["0.0.0.0/0"]
-#   layer4_configs {
-#     ip_protocol = "all"
-#   }
-# }
-#}
-
-resource "google_compute_network_firewall_policy_rule" "default-deny-egress" {
-  description     = "Catch-all deny egress rule to block traffic that has not been explicitly allowed"
-  action          = "deny"
-  direction       = "EGRESS"
-  enable_logging  = true
-  firewall_policy = google_compute_network_firewall_policy.policy.name
-  priority        = 65530
-  rule_name       = "default-deny-egress"
-
-  match {
-    dest_ip_ranges = ["0.0.0.0/0"]
-    layer4_configs {
-      ip_protocol = "all"
-    }
-  }
-}
-
-
 module "dns-private-zone-googleapis" {
   source     = "github.com/terraform-google-modules/terraform-google-cloud-dns?ref=92bd8140d059388c6c22742ffcb5f4ab2c24cee9" #commit hash of version 5.3.0
   project_id = var.project_id

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -21,6 +21,8 @@ module "vpc" {
 
   subnets = []
 
+  depends_on = [module.project_services]
+
 }
 
 resource "google_dns_policy" "dns-policy" {

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -131,22 +131,22 @@ resource "google_compute_network_firewall_policy_rule" "allow-composer-control-p
   }
 }
 
-resource "google_compute_network_firewall_policy_rule" "allow-composer-sql" {
-  description     = "Allow internal traffic to reach the sql in tenant project"
-  action          = "allow"
-  direction       = "EGRESS"
-  enable_logging  = true
-  firewall_policy = google_compute_network_firewall_policy.policy.name
-  priority        = 1005
-  rule_name       = "allow-composer-sql"
+#resource "google_compute_network_firewall_policy_rule" "allow-composer-sql" {
+#  description     = "Allow internal traffic to reach the sql in tenant project"
+#  action          = "allow"
+#  direction       = "EGRESS"
+#  enable_logging  = true
+#  firewall_policy = google_compute_network_firewall_policy.policy.name
+#  priority        = 1005
+#  rule_name       = "allow-composer-sql"
 
-  match {
-    dest_ip_ranges = [var.composer_cidr.sql]
-    layer4_configs {
-      ip_protocol = "all"
-    }
-  }
-}
+#  match {
+#    dest_ip_ranges = [var.composer_cidr.sql]
+#    layer4_configs {
+#    ip_protocol = "all"
+#   }
+#  }
+#}
 
 #resource "google_compute_network_firewall_policy_rule" "default-deny-egress-logger" {
 #  description     = "Logger"
@@ -281,27 +281,6 @@ module "dns-private-zone-gcr-io" {
   type       = "private"
   name       = "gcr-io"
   domain     = "gcr.io."
-
-  private_visibility_config_networks = [module.vpc[0].network_self_link]
-
-  recordsets = [
-    {
-      name = "*"
-      type = "CNAME"
-      ttl  = 300
-      records = [
-        "private.googleapis.com.",
-      ]
-    },
-  ]
-}
-
-module "dns-private-zone-catchall" {
-  source     = "github.com/terraform-google-modules/terraform-google-cloud-dns?ref=92bd8140d059388c6c22742ffcb5f4ab2c24cee9" #commit hash of version 5.3.0
-  project_id = var.project_id
-  type       = "private"
-  name       = "catchall"
-  domain     = "."
 
   private_visibility_config_networks = [module.vpc[0].network_self_link]
 

--- a/components/dpu-workflow/terraform/main.tf
+++ b/components/dpu-workflow/terraform/main.tf
@@ -59,6 +59,7 @@ module "dpu-subnet" {
     subnet_ip             = "10.10.10.0/24"
     subnet_region         = var.region
     subnet_private_access = "true"
+    subnet_flow_logs      = "true"
   }]
 
   secondary_ranges = {

--- a/components/dpu-workflow/terraform/main.tf
+++ b/components/dpu-workflow/terraform/main.tf
@@ -56,7 +56,7 @@ module "dpu-subnet" {
 
   subnets = [{
     subnet_name           = "composer-subnet"
-    subnet_ip             = "10.10.10.0/24"
+    subnet_ip             = var.composer_cidr.primary
     subnet_region         = var.region
     subnet_private_access = "true"
     subnet_flow_logs      = "true"
@@ -66,11 +66,11 @@ module "dpu-subnet" {
     composer-subnet = [
       {
         range_name    = local.cluster_secondary_range_name
-        ip_cidr_range = "10.154.0.0/17"
+        ip_cidr_range = var.composer_cidr.cluster_secondary_range
       },
       {
         range_name    = local.services_secondary_range_name
-        ip_cidr_range = "10.154.128.0/22"
+        ip_cidr_range = var.composer_cidr.services_secondary_range
       },
     ]
   }

--- a/components/dpu-workflow/terraform/main.tf
+++ b/components/dpu-workflow/terraform/main.tf
@@ -56,7 +56,7 @@ module "dpu-subnet" {
 
   subnets = [{
     subnet_name           = "composer-subnet"
-    subnet_ip             = var.composer_cidr.primary
+    subnet_ip             = var.composer_cidr.subnet_primary
     subnet_region         = var.region
     subnet_private_access = "true"
     subnet_flow_logs      = "true"

--- a/components/dpu-workflow/terraform/variables.tf
+++ b/components/dpu-workflow/terraform/variables.tf
@@ -80,3 +80,12 @@ variable "composer_sa_roles" {
     "roles/discoveryengine.editor",
   ]
 }
+
+variable "composer_cidr" {
+  description = "CIDR ranges for configuring Cloud Composer"
+  type = object({
+    primary                  = string
+    cluster_secondary_range  = string
+    services_secondary_range = string
+  })
+}

--- a/components/dpu-workflow/terraform/variables.tf
+++ b/components/dpu-workflow/terraform/variables.tf
@@ -84,8 +84,10 @@ variable "composer_sa_roles" {
 variable "composer_cidr" {
   description = "CIDR ranges for configuring Cloud Composer"
   type = object({
-    primary                  = string
+    subnet_primary           = string
     cluster_secondary_range  = string
     services_secondary_range = string
+    control_plane            = string
+    sql                      = string
   })
 }

--- a/components/processing/terraform/main.tf
+++ b/components/processing/terraform/main.tf
@@ -48,8 +48,7 @@ module "project_services" {
       "api" : "pubsub.googleapis.com",
       # PubSub publish to Cloud Run
       "roles" : [
-        #"roles/iam.serviceAccountUser",
-        "roles/iam.serviceAccountTokenCreator",
+        "roles/iam.serviceAccountUser",
       ],
     }
   ]

--- a/components/webui/terraform/cloudrun.tf
+++ b/components/webui/terraform/cloudrun.tf
@@ -106,7 +106,6 @@ module "eks_webui_lb" {
   managed_ssl_certificate_domains = var.lb_ssl_certificate_domains
   ssl                             = true
   ssl_policy                      = google_compute_ssl_policy.ssl-policy.self_link
-  https_redirect                  = true
   labels                          = local.eks_label
 
   backends = {
@@ -129,8 +128,6 @@ module "eks_webui_lb" {
       }
     }
   }
-
-  depends_on = [google_compute_ssl_policy.ssl-policy]
 }
 
 resource "google_project_service_identity" "iap_sa" {

--- a/components/webui/terraform/cloudrun.tf
+++ b/components/webui/terraform/cloudrun.tf
@@ -93,12 +93,19 @@ resource "google_compute_region_network_endpoint_group" "eks_webui_neg" {
   }
 }
 
+resource "google_compute_ssl_policy" "ssl-policy" {
+  name            = "ssl-policy"
+  profile         = "MODERN"
+  min_tls_version = "TLS_1_2"
+}
+
 module "eks_webui_lb" {
   source                          = "github.com/terraform-google-modules/terraform-google-lb-http.git//modules/serverless_negs?ref=99d56bea9a7f561102d2e449852eaf725e8b8d0c" # version 12.0.0
   name                            = "eks-webui-lb"
   project                         = var.project_id
   managed_ssl_certificate_domains = var.lb_ssl_certificate_domains
   ssl                             = true
+  ssl_policy                      = google_compute_ssl_policy.ssl-policy.self_link
   https_redirect                  = true
   labels                          = local.eks_label
 
@@ -122,12 +129,8 @@ module "eks_webui_lb" {
       }
     }
   }
-}
 
-resource "google_compute_ssl_policy" "nonprod-ssl-policy" {
-  name            = "ssl-policy"
-  profile         = "MODERN"
-  min_tls_version = "TLS_1_2"
+  depends_on = [google_compute_ssl_policy.ssl-policy]
 }
 
 resource "google_project_service_identity" "iap_sa" {

--- a/components/webui/terraform/cloudrun.tf
+++ b/components/webui/terraform/cloudrun.tf
@@ -118,10 +118,16 @@ module "eks_webui_lb" {
         oauth2_client_secret = google_iap_client.project_client.secret
       }
       log_config = {
-        enable = false
+        enable = true
       }
     }
   }
+}
+
+resource "google_compute_ssl_policy" "nonprod-ssl-policy" {
+  name            = "ssl-policy"
+  profile         = "MODERN"
+  min_tls_version = "TLS_1_2"
 }
 
 resource "google_project_service_identity" "iap_sa" {

--- a/components/webui/terraform/cloudrun.tf
+++ b/components/webui/terraform/cloudrun.tf
@@ -106,6 +106,7 @@ module "eks_webui_lb" {
   managed_ssl_certificate_domains = var.lb_ssl_certificate_domains
   ssl                             = true
   ssl_policy                      = google_compute_ssl_policy.ssl-policy.self_link
+  https_redirect                  = true
   labels                          = local.eks_label
 
   backends = {

--- a/sample-deployments/composer-orchestrated-process/main.tf
+++ b/sample-deployments/composer-orchestrated-process/main.tf
@@ -34,6 +34,7 @@ module "common_infra" {
   create_vpc_network = var.create_vpc_network
   vpc_name           = var.vpc_name
   vpc_id             = var.vpc_id
+  composer_cidr      = var.composer_cidr
 }
 
 module "project_services" {
@@ -122,6 +123,7 @@ module "dpu_workflow" {
   project_id       = var.project_id
   vpc_network_name = module.common_infra.vpc_network_name
   vpc_network_id   = module.common_infra.vpc_network_id
+  composer_cidr    = var.composer_cidr
   composer_env_variables = {
     DPU_OUTPUT_DATASET      = module.common_infra.bq_store_dataset_id
     DPU_INPUT_BUCKET        = module.common_infra.gcs_input_bucket_name

--- a/sample-deployments/composer-orchestrated-process/project_roles.txt
+++ b/sample-deployments/composer-orchestrated-process/project_roles.txt
@@ -8,6 +8,7 @@ roles/compute.networkAdmin
 roles/compute.securityAdmin
 roles/container.clusterAdmin
 roles/discoveryengine.admin
+roles/dns.admin
 roles/documentai.admin
 roles/iam.serviceAccountAdmin
 roles/iam.serviceAccountUser

--- a/sample-deployments/composer-orchestrated-process/variables.tf
+++ b/sample-deployments/composer-orchestrated-process/variables.tf
@@ -66,3 +66,17 @@ variable "webui_domains" {
   description = "Custom domain pointing to the WebUI app, DNS configured"
   type        = list(string)
 }
+
+variable "composer_cidr" {
+  description = "CIDR ranges for configuring Cloud Composer"
+  type = object({
+    primary                  = string
+    cluster_secondary_range  = string
+    services_secondary_range = string
+  })
+  default = {
+    primary                  = "10.10.10.0/24"
+    cluster_secondary_range  = "10.154.0.0/17"
+    services_secondary_range = "10.154.128.0/22"
+  }
+}

--- a/sample-deployments/composer-orchestrated-process/variables.tf
+++ b/sample-deployments/composer-orchestrated-process/variables.tf
@@ -70,13 +70,17 @@ variable "webui_domains" {
 variable "composer_cidr" {
   description = "CIDR ranges for configuring Cloud Composer"
   type = object({
-    primary                  = string
+    subnet_primary           = string
     cluster_secondary_range  = string
     services_secondary_range = string
+    control_plane            = string
+    sql                      = string
   })
   default = {
-    primary                  = "10.10.10.0/24"
+    subnet_primary           = "10.10.10.0/24"
     cluster_secondary_range  = "10.154.0.0/17"
     services_secondary_range = "10.154.128.0/22"
+    control_plane            = "172.31.245.0/24"
+    sql                      = "10.0.0.0/12"
   }
 }


### PR DESCRIPTION
A fresh deployment was triggering various SHA vulnerability findings in Security Command Center. I've modified our resource configurations to mitigate all the vulnerabilities of severity=(high|medium) and source=SHA. This excludes source="GKE Security Posture", most of which is unconfigurable when using Composer v2 but we can later address with Composer v3 based on GKE autopilot.

Summary of actions taken:

Fixed:
 - EGRESS_DENY_RULE_NOT_SET
 - FLOW_LOGS_DISABLED
 - OSLOGIN_DISABLED
 - HTTP_LOAD_BALANCER
 - DNS_LOGGING_DISABLED
 - LOAD_BALANCER_LOGGING_DISABLED
 - WEAK_SSL_POLICY
 - PRIMTIVE_ROLES_USED


Won't fix
 - *_NOT_MONITORED: CIS guidance requires creating unhelpful alerts that are high-noise low-value signals, and the specific implementation method that CIS dictates is impactical at scale, so we won't include them in this repo
 - AUDIT_LOGGING_DISABLED: CIS gives poor guidance to enable data access logs on all resources everywhere, this is typically high-noise and high-cost, data access logs should be enabled selectively based on data requirements.
 - BUCKET_LOGGING_DISABLED: this is a relic of CIS 1.0 and no longer recommended for any customer
 - ADMIN_SERVICE_ACCOUNT, OVER_PRIVILEGED_SERVICE_ACCOUNT_USER, SERVICE_ACCOUNT_ROLE_SEPARATION : Fixing these would require refactoring the deployer service accounts into many smaller service accounts with separate Terraform stages, which adds significant complexity for little security value in this case. It is expected that a service account used in a Terraform pipeline has significant privileges to modify project resources.
 - LOG_NOT_EXPORTED: this requires foundational/operational controls outside the scope of this repo
 - CLUSTER_SECRETS_ENCRYPTION_DISABLED, BINARY AUTHORIZATION DISABLED:  foundational/operational controls outside the scope of this repo.