### PR TITLE
fix: remove dependencies on default compute service account

### DIFF
--- a/components/doc-registry/terraform/build.tf
+++ b/components/doc-registry/terraform/build.tf
@@ -25,7 +25,7 @@ locals {
 }
 
 # See github.com/terraform-google-modules/terraform-google-gcloud
-module "gcloud" {
+module "gcloud_build_doc_registry" {
   source                = "github.com/terraform-google-modules/terraform-google-gcloud?ref=db25ab9c0e9f2034e45b0034f8edb473dde3e4ff" # commit hash of version 3.5.0
   create_cmd_entrypoint = "gcloud"
   create_cmd_body       = <<-EOT
@@ -33,6 +33,8 @@ module "gcloud" {
       --pack image=${local.image_name_and_tag} \
       --project ${var.project_id} \
       --region ${var.region}
+      --default-buckets-behavior=regional-user-owned-bucket \
+      --service-account "projects/${var.project_id}/serviceAccounts/${var.cloud_build_service_account_email}"
   EOT
   enabled               = true
 

--- a/components/doc-registry/terraform/build.tf
+++ b/components/doc-registry/terraform/build.tf
@@ -32,7 +32,7 @@ module "gcloud_build_doc_registry" {
     builds submit ${path.module}/../src \
       --pack image=${local.image_name_and_tag} \
       --project ${var.project_id} \
-      --region ${var.region}
+      --region ${var.region} \
       --default-buckets-behavior=regional-user-owned-bucket \
       --service-account "projects/${var.project_id}/serviceAccounts/${var.cloud_build_service_account_email}"
   EOT

--- a/components/doc-registry/terraform/main.tf
+++ b/components/doc-registry/terraform/main.tf
@@ -87,6 +87,6 @@ resource "google_cloud_run_v2_job" "doc-registry-service-job" {
     }
   }
   depends_on = [
-    module.gcloud.wait
+    module.gcloud_build_doc_registry.wait
   ]
 }

--- a/components/doc-registry/terraform/variables.tf
+++ b/components/doc-registry/terraform/variables.tf
@@ -45,3 +45,8 @@ variable "artifact_repo" {
   type        = string
   default     = ""
 }
+
+variable "cloud_build_service_account_email" {
+  description = "the user-managed service account configured for Cloud Build"
+  type        = string
+}

--- a/components/dpu-workflow/terraform/main.tf
+++ b/components/dpu-workflow/terraform/main.tf
@@ -75,24 +75,6 @@ module "dpu-subnet" {
   }
 }
 
-data "google_compute_default_service_account" "default" {
-  project = module.project_services.project_id
-}
-
-# Grant default compute engine view access to cloud storage
-resource "google_project_iam_member" "gce_gcs_access" {
-  project = module.project_services.project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
-}
-# Grant default compute engine view access to artifact registry
-resource "google_project_iam_member" "gce_ar_access" {
-  project = module.project_services.project_id
-  role    = "roles/artifactregistry.writer"
-  member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
-}
-
-
 resource "google_composer_environment" "composer_env" {
   project = module.project_services.project_id
   name    = local.env_name
@@ -120,11 +102,6 @@ resource "google_composer_environment" "composer_env" {
       }
     }
   }
-
-  depends_on = [
-    google_project_iam_member.gce_gcs_access,
-    google_project_iam_member.gce_ar_access
-  ]
 }
 
 resource "google_storage_bucket_object" "workflow_orchestrator_dag" {

--- a/components/dpu-workflow/terraform/main.tf
+++ b/components/dpu-workflow/terraform/main.tf
@@ -37,6 +37,11 @@ module "project_services" {
   }]
 }
 
+resource "google_project_default_service_accounts" "disable_default_service_accounts" {
+  project = var.project_id
+  action  = "DISABLE"
+}
+
 module "composer_service_account" {
   source = "github.com/terraform-google-modules/terraform-google-service-accounts?ref=a11d4127eab9b51ec9c9afdaf51b902cd2c240d9" #commit hash of version 4.0.0
 

--- a/sample-deployments/composer-orchestrated-process/main.tf
+++ b/sample-deployments/composer-orchestrated-process/main.tf
@@ -185,8 +185,9 @@ resource "local_file" "env_file" {
 }
 
 module "doc_registry" {
-  source        = "../../components/doc-registry/terraform"
-  project_id    = var.project_id
-  region        = var.region
-  artifact_repo = module.common_infra.artifact_repo.name
+  source                            = "../../components/doc-registry/terraform"
+  project_id                        = var.project_id
+  region                            = var.region
+  artifact_repo                     = module.common_infra.artifact_repo.name
+  cloud_build_service_account_email = module.common_infra.cloud_build_service_account.email
 }


### PR DESCRIPTION
remove and test references to default compute service account. Disable the account while int test is running to validate if there are other unknown dependencies.