### PR TITLE
feat: additional IAM roles for deployer sa

### DIFF
--- a/sample-deployments/composer-orchestrated-process/persona_roles_DEPLOYER.txt
+++ b/sample-deployments/composer-orchestrated-process/persona_roles_DEPLOYER.txt
@@ -4,6 +4,7 @@ roles/artifactregistry.admin
 roles/bigquery.dataOwner
 roles/cloudbuild.builds.builder
 roles/composer.admin
+roles/compute.loadBalancerAdmin)
 roles/compute.networkAdmin
 roles/compute.securityAdmin
 roles/container.clusterAdmin
@@ -20,3 +21,4 @@ roles/logging.logWriter
 roles/servicedirectory.admin
 roles/serviceusage.serviceUsageAdmin
 roles/storage.admin
+roles/vpcaccess.admin


### PR DESCRIPTION
Added 2 roles for the deployer service account, VPC Access Admin and Network Load Balancer Admin.

Somehow the CI tests were passing successfully without these, but we sometimes see IAM errors related to these when modifying resources after the initial deployment.