### PR TITLE
chore(deps): reduce noise from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
 
   - package-ecosystem: "terraform"
     directory: "/components"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
 
 version: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,4 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "pip"
-    directory: "/components"
-    schedule:
-      interval: "weekly"
 version: 2


### PR DESCRIPTION
disable python dependency upgrades from dependabot. 
The automatic PRs are updating a single library at a time, which tends to break our constraints. We need to use `./invoke.sh lock --upgrade` instead to update all libraries consistently.

Dependabot will still create security alerts for upgrades based on CVE and available updates (security tab in upper right of GitHub console) but not try to automatically raise a PR.