### PR TITLE
chore(variables): Cleanup default variables

### DIFF
--- a/components/webui/terraform/build.tf
+++ b/components/webui/terraform/build.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 locals {
-  ui_service_name     = "eks-ui"
   cloud_build_fileset = setunion(fileset(path.module, "../src/**"), fileset(path.module, "build/Dockerfile"), fileset(path.module, "../requirements.txt"), fileset(path.module, "build/cloudbuild.yaml"))
   cloud_build_content_hash = sha512(join(",", [
   for f in local.cloud_build_fileset : fileexists("${path.module}/${f}") ? filesha512("${path.module}/${f}") : sha512("file-not-found")]))
@@ -24,7 +23,7 @@ resource "local_file" "cloudbuild_config" {
   content = templatefile("${path.module}/build/cloudbuild.yaml.template", {
     project_id            = var.project_id,
     build_service_account = var.cloud_build_service_account_email,
-    image_tag             = "${var.region}-docker.pkg.dev/${module.project_services.project_id}/${var.artifact_repo}/${local.ui_service_name}"
+    image_tag             = "${var.region}-docker.pkg.dev/${module.project_services.project_id}/${var.artifact_repo}/${var.webui_service_name}"
   })
 }
 

--- a/components/webui/terraform/cloudrun.tf
+++ b/components/webui/terraform/cloudrun.tf
@@ -82,6 +82,7 @@ resource "google_cloud_run_v2_service" "eks_webui" {
   depends_on = [
     module.gcloud_build_app.wait
   ]
+  deletion_protection = false
 }
 
 resource "google_compute_region_network_endpoint_group" "eks_webui_neg" {
@@ -90,6 +91,9 @@ resource "google_compute_region_network_endpoint_group" "eks_webui_neg" {
   region                = var.region
   cloud_run {
     service = google_cloud_run_v2_service.eks_webui.name
+  }
+  lifecycle {
+    replace_triggered_by = [google_cloud_run_v2_service.eks_webui]
   }
 }
 

--- a/components/webui/terraform/cloudrun.tf
+++ b/components/webui/terraform/cloudrun.tf
@@ -86,7 +86,7 @@ resource "google_cloud_run_v2_service" "eks_webui" {
 }
 
 resource "google_compute_region_network_endpoint_group" "eks_webui_neg" {
-  name                  = "eks-webui-neg"
+  name                  = "${var.webui_service_name}-neg"
   network_endpoint_type = "SERVERLESS"
   region                = var.region
   cloud_run {
@@ -105,7 +105,7 @@ resource "google_compute_ssl_policy" "ssl-policy" {
 
 module "eks_webui_lb" {
   source                          = "github.com/terraform-google-modules/terraform-google-lb-http.git//modules/serverless_negs?ref=99d56bea9a7f561102d2e449852eaf725e8b8d0c" # version 12.0.0
-  name                            = "eks-webui-lb"
+  name                            = "${var.webui_service_name}-lb"
   project                         = var.project_id
   managed_ssl_certificate_domains = var.lb_ssl_certificate_domains
   ssl                             = true

--- a/components/webui/terraform/cloudrun.tf
+++ b/components/webui/terraform/cloudrun.tf
@@ -49,7 +49,7 @@ resource "google_cloud_run_v2_service" "eks_webui" {
       max_instance_count = 2
     }
     containers {
-      image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.artifact_repo}/${local.ui_service_name}:latest"
+      image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.artifact_repo}/${var.webui_service_name}:latest"
       ports {
         container_port = 8080
       }

--- a/components/webui/terraform/variables.tf
+++ b/components/webui/terraform/variables.tf
@@ -19,19 +19,17 @@ variable "project_id" {
 
 variable "region" {
   type        = string
-  description = "Google Cloud region where app engine is located "
+  description = "Google Cloud region where resources are located "
 }
 
 variable "artifact_repo" {
   description = "Docker registry"
   type        = string
-  default     = ""
 }
 
 variable "cloud_build_service_account_email" {
   description = "IAM service account email used for cloud build."
   type        = string
-  default     = ""
 }
 
 variable "iap_access_domains" {
@@ -56,7 +54,8 @@ variable "agent_builder_search_id" {
 
 variable "webui_service_name" {
   type        = string
-  description = "The App Engine service name for the webui"
+  description = "The service name for the webui"
+  default     = "eks-ui"
 }
 
 variable "lb_ssl_certificate_domains" {

--- a/sample-deployments/composer-orchestrated-process/main.tf
+++ b/sample-deployments/composer-orchestrated-process/main.tf
@@ -149,7 +149,6 @@ module "dpu_ui" {
   vertex_ai_data_store_region       = var.vertex_ai_data_store_region
   agent_builder_data_store_id       = google_discovery_engine_data_store.dpu_ds.data_store_id
   agent_builder_search_id           = google_discovery_engine_search_engine.basic.engine_id
-  webui_service_name                = var.webui_service_name
   lb_ssl_certificate_domains        = var.webui_domains
 }
 

--- a/sample-deployments/composer-orchestrated-process/variables.tf
+++ b/sample-deployments/composer-orchestrated-process/variables.tf
@@ -32,12 +32,6 @@ variable "iap_access_domains" {
   type        = list(string)
 }
 
-variable "webui_service_name" {
-  type        = string
-  description = "Specify the WebUI App Engine service name, use the default value when doing initial deployment. Change the default value after the initial deployment and re-apply terraform"
-  default     = "default"
-}
-
 variable "docai_location" {
   description = "Google Cloud region where compute services are located."
   type        = string


### PR DESCRIPTION
 - Remove references to app engine and simplify how the web-ui name is set as a default variable. (No need to make this a required input for first setup, pass it between modules, and also set it as a local variable).
 - add arguments to properly map resource dependencies and avoid errors about 409 and deletion protection that commonly break subsequent runs