### PR TITLE
fix: replace "serverless vpc connector" model with "direct vpc egress" model

### DIFF
--- a/components/common-infra/terraform/alloydb.tf
+++ b/components/common-infra/terraform/alloydb.tf
@@ -12,17 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "google_vpc_access_connector" "vpc_connector" {
-  project = module.project_services.project_id
-  name    = "alloy-db-vpc-connector"
-  region  = var.region
-  subnet {
-    name = google_compute_subnetwork.serverless_connector_subnet.name
-  }
-  min_instances = 2
-  max_instances = 3
-}
-
 resource "google_compute_subnetwork" "serverless_connector_subnet" {
   name                     = var.serverless_connector_subnet
   ip_cidr_range            = var.serverless_connector_subnet_range

--- a/components/specialized-parser/terraform/main.tf
+++ b/components/specialized-parser/terraform/main.tf
@@ -103,7 +103,7 @@ resource "google_cloud_run_v2_job" "specialized_parser_processor_job" {
           network    = var.network
           subnetwork = var.serverless_connector_subnet
         }
-        egress = "PRIVATE_RANGES_ONLY"
+        egress = "ALL_TRAFFIC"
       }
       containers {
         image = local.image_name_and_tag

--- a/sample-deployments/composer-orchestrated-process/variables.tf
+++ b/sample-deployments/composer-orchestrated-process/variables.tf
@@ -88,7 +88,7 @@ variable "serverless_connector_subnet" {
 variable "serverless_connector_subnet_range" {
   description = "Range of the VPC subnet to create"
   type        = string
-  default     = "10.2.0.0/28"
+  default     = "10.2.0.0/24"
 }
 
 variable "psa_reserved_address" {


### PR DESCRIPTION
Root cause analysis of "Instance failed to start because of insufficient free IP addresses in the subnetwork https://www.googleapis.com/compute/v1/projects/dpu-demo/regions/us-central1/subnetworks/cloudrun-to-alloydb-connector-subnet when attempting to create an address in the subnetwork. Please consider moving to a subnetwork with more available IP addresses."

- The network setup for Cloud Run traffic to reach the VPC was straddling two different models, terraform code created a [serverless VPC access connector](https://cloud.google.com/run/docs/configuring/vpc-connectors) which was unused, but the Cloud Run job was configured to use [direct VPC egress](https://cloud.google.com/run/docs/configuring/vpc-direct-vpc) instead. We were creating two different subnets for something that should require one.
- In PR 165 I noticed the connector was unused, I thought I was correcting that by combining the subnets (but didn't realize the two models were mixed).
- tests for infra CI succeed because the infra can be created, but direct vpc egress was failing when the cloud run job runs (after infra is deployed). The access connector must have a precisely /28 subnet used for nothing else, the direct egress model takes any subnet and tries to take an IP from it, so combining the models can't be done.
- This PR fixes it to only configure direct vpc egress on the Cloud Run job, and removes the VPC access connector. (the vpc access connector is a legacy model that customers disliked, product teams are encouraging everyone to migrate from it)

Caveat: modifying the subnet and testing is difficult because the reservation lasts for a few hours after deleting Cloud Run, so you might have resources that can't be deleted:
https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#delete-subnet