### PR TITLE
fix: Minor fixes from ce feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To deploy the Infrastructure-as-Code (IaC) resources needed for this solution, p
 1. In Cloud Shell or your preferred terminal, clone this repository:
 
    ```sh
-   git clone https://github.com/GoogleCloudPlatform/document-processing-and-understanding.git
+   git clone https://github.com/GoogleCloudPlatform/enterprise-knowledge-solution.git
    ```
 
 1. Navigate to the Sample Directory:

--- a/sample-deployments/composer-orchestrated-process/scripts/common.sh
+++ b/sample-deployments/composer-orchestrated-process/scripts/common.sh
@@ -176,8 +176,8 @@ enable_api() {
 # enable all apis in the array
 enable_bootstrap_apis() {
   apis_array=()
-  while read project_api; do
-    apis_array+=($project_api)
+  while read -r project_api; do
+    apis_array+=("$project_api")
   done <"$PARENT_DIR/../project_apis.txt"
 
   for i in "${apis_array[@]}"; do
@@ -199,8 +199,8 @@ enable_persona_roles() {
   local __persona_name=$3
 
   roles_array=()
-  while read role; do
-    roles_array+=($role)
+  while read -r role; do
+    roles_array+=("$role")
   done <"$PARENT_DIR/../$__arrayfile"
 
   for i in "${roles_array[@]}"; do

--- a/sample-deployments/composer-orchestrated-process/scripts/common.sh
+++ b/sample-deployments/composer-orchestrated-process/scripts/common.sh
@@ -175,7 +175,11 @@ enable_api() {
 
 # enable all apis in the array
 enable_bootstrap_apis() {
-  apis_array=( $(cat "$PARENT_DIR/../project_apis.txt") )
+  apis_array=()
+  while read project_api; do
+    apis_array+=($project_api)
+  done <"$PARENT_DIR/../project_apis.txt"
+
   for i in "${apis_array[@]}"; do
     enable_api "$i"
   done
@@ -193,7 +197,11 @@ enable_persona_roles() {
   local __principal=$1
   local __arrayfile=$2
   local __persona_name=$3
-  roles_array=( $(cat "$PARENT_DIR/../$__arrayfile") )
+
+  roles_array=()
+  while read role; do
+    roles_array+=($role)
+  done <"$PARENT_DIR/../$__arrayfile"
 
   for i in "${roles_array[@]}"; do
     if [ "$__persona_name" == "READER" ] && [ "$i" == "roles/storage.objectViewer" ]; then

--- a/sample-deployments/composer-orchestrated-process/scripts/common.sh
+++ b/sample-deployments/composer-orchestrated-process/scripts/common.sh
@@ -175,7 +175,7 @@ enable_api() {
 
 # enable all apis in the array
 enable_bootstrap_apis() {
-  readarray -t apis_array <"$PARENT_DIR"/../project_apis.txt
+  apis_array=( $(cat "$PARENT_DIR/../project_apis.txt") )
   for i in "${apis_array[@]}"; do
     enable_api "$i"
   done
@@ -193,7 +193,8 @@ enable_persona_roles() {
   local __principal=$1
   local __arrayfile=$2
   local __persona_name=$3
-  readarray -t roles_array <"$PARENT_DIR/../$__arrayfile"
+  roles_array=( $(cat "$PARENT_DIR/../$__arrayfile") )
+
   for i in "${roles_array[@]}"; do
     if [ "$__persona_name" == "READER" ] && [ "$i" == "roles/storage.objectViewer" ]; then
       #Most roles for most persona are project-level, but READER requires one bucket-level role.

--- a/sample-deployments/composer-orchestrated-process/scripts/reset_datastore.sh
+++ b/sample-deployments/composer-orchestrated-process/scripts/reset_datastore.sh
@@ -89,10 +89,8 @@ document_names=$(echo "$response" | jq -r '.documents[].name' | awk -F '/' '{pri
 printf "%s\n" "${document_names}"
 
 # Create an array from the extracted information
-readarray -t document_list <<<"$document_names"
-
-# Print the list (optional)
-printf "%s\n" "${document_list[@]}"
+document_list=()
+printf "%s\0" "$document_names" | xargs -0 -n1 bash -c 'document_list+=("$@")' _
 
 # Confirmation prompt
 read -r -p "You are about to delete all documents from project '$PROJECT_ID'. Are you sure? [y/N] " response


### PR DESCRIPTION
 - README clone URL still uses the old repo [Ref](https://github.com/GoogleCloudPlatform/enterprise-knowledge-solution/blob/main/README.md?plain=1#L66)
 - sample-deployments/composer-orchestrated-process/scripts/common.sh uses readarray which is not available on OS X