### PR TITLE
feat: upgrade PSA to PSC for alloydb

### DIFF
--- a/components/common-infra/terraform/alloydb.tf
+++ b/components/common-infra/terraform/alloydb.tf
@@ -25,39 +25,21 @@ resource "google_compute_subnetwork" "serverless_connector_subnet" {
   }
 }
 
-resource "google_compute_global_address" "private_ip_address" {
-  name          = "private-ip-address"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 24
-  network       = local.vpc_network_id
-  address       = var.psa_reserved_address
-}
-
-resource "google_service_networking_connection" "default" {
-  network                 = local.vpc_network_id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
-}
-
-resource "google_compute_network_peering_routes_config" "peering_routes" {
-  peering = google_service_networking_connection.default.peering
-  network = local.vpc_network_name
-
-  import_custom_routes = true
-  export_custom_routes = true
+data "google_project" "eks_project" {
+  project_id = var.project_id
 }
 
 module "docs_results" {
-  source = "github.com/GoogleCloudPlatform/terraform-google-alloy-db?ref=fa1d5faf54b56abfe410f5c29483e365d48ec1a3" #commit hash for version 3.2.0
+  source = "github.com/GoogleCloudPlatform/terraform-google-alloy-db?ref=eda758770239cd3dd1122834ef0c0429659a0234" #commit hash for version 3.2.1
 
   project_id = module.project_services.project_id
 
-  cluster_id        = var.alloy_db_cluster_id
-  cluster_location  = var.region
-  cluster_labels    = {}
-  psc_enabled       = false
-  network_self_link = replace(local.vpc_network_self_link, "https://www.googleapis.com/compute/v1/", "")
+  cluster_id                    = var.alloy_db_cluster_id
+  cluster_location              = var.region
+  cluster_labels                = {}
+  psc_enabled                   = true
+  network_self_link             = null
+  psc_allowed_consumer_projects = [data.google_project.eks_project.number]
 
 
   primary_instance = {
@@ -70,8 +52,41 @@ module "docs_results" {
       "password.enforce_complexity" = "on"
     }
   }
+}
 
-  depends_on = [google_service_networking_connection.default]
+resource "google_compute_address" "alloydb_psc_endpoint" {
+  region       = var.region
+  name         = var.alloydb_psc_endpoint
+  subnetwork   = google_compute_subnetwork.serverless_connector_subnet.id
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "alloydb_psc_fwd_rule" {
+  region                  = var.region
+  name                    = var.alloydb_psc_fwd_rule
+  target                  = module.docs_results.primary_psc_attachment_link
+  load_balancing_scheme   = "" # need to override EXTERNAL default when target is a service attachment
+  network                 = local.vpc_network_id
+  ip_address              = google_compute_address.alloydb_psc_endpoint.id
+  allow_psc_global_access = true
+}
+resource "google_dns_managed_zone" "alloydb_dns" {
+  name        = var.alloydb_dns
+  dns_name    = module.docs_results.primary_psc_dns_name
+  description = "DNS Zone for EKS AlloyDB instance"
+  visibility  = "private"
+  private_visibility_config {
+    networks {
+      network_url = local.vpc_network_id
+    }
+  }
+}
+resource "google_dns_record_set" "alloy_psc" {
+  name         = module.docs_results.primary_psc_dns_name
+  type         = "A"
+  ttl          = 300
+  managed_zone = google_dns_managed_zone.alloydb_dns.name
+  rrdatas      = [google_compute_address.alloydb_psc_endpoint.address]
 }
 
 resource "time_sleep" "wait_for_alloydb_ready_state" {

--- a/components/common-infra/terraform/variables.tf
+++ b/components/common-infra/terraform/variables.tf
@@ -67,8 +67,21 @@ variable "serverless_connector_subnet_range" {
   type        = string
 }
 
-variable "psa_reserved_address" {
-  description = "First address of CIDR range to reserve for the Private Services Access connection used by AlloyDB. The prefix_length is configured separately in terraform."
+variable "alloydb_psc_endpoint" {
+  description = "Name of Private Service Connect endpoint used for access to AlloyDB from your VPC"
   type        = string
-  default     = "10.240.0.0"
+  default     = "alloydb-psc-endpoint"
 }
+
+variable "alloydb_psc_fwd_rule" {
+  description = "Name of the forwarding rule associated with the alloydb PSC endpoint"
+  type        = string
+  default     = "alloydb-psc-fwd-rule"
+}
+
+variable "alloydb_dns" {
+  description = "Name of the DNS zone associated with AlloyDB PSC access"
+  type        = string
+  default     = "alloydb-dns"
+}
+

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -78,6 +78,26 @@ resource "google_compute_network_firewall_policy_rule" "allow-google-apis" {
   }
 }
 
+resource "google_compute_network_firewall_policy_rule" "allow-psc-to-alloydb" {
+  count           = var.create_vpc_network ? 1 : 0
+  description     = "Allow egress to PSC endpoint used for AlloyDB"
+  action          = "allow"
+  direction       = "EGRESS"
+  enable_logging  = true
+  firewall_policy = google_compute_network_firewall_policy.policy[0].name
+  priority        = 1011
+  rule_name       = "allow-psc-to-alloydb"
+
+  match {
+    dest_ip_ranges = ["${google_compute_address.alloydb_psc_endpoint.address}/32"]
+    layer4_configs {
+      ip_protocol = "tcp"
+      ports       = ["5433"]
+    }
+  }
+}
+
+
 resource "google_compute_network_firewall_policy_rule" "allow-google-apis-directpath" {
   count           = var.create_vpc_network ? 1 : 0
   description     = "Allow private HTTPS access to google services that bypass GFE (Composer 3)"

--- a/components/common-infra/terraform/vpc.tf
+++ b/components/common-infra/terraform/vpc.tf
@@ -78,21 +78,20 @@ resource "google_compute_network_firewall_policy_rule" "allow-google-apis" {
   }
 }
 
-resource "google_compute_network_firewall_policy_rule" "allow-psa-to-alloydb" {
+resource "google_compute_network_firewall_policy_rule" "allow-google-apis-directpath" {
   count           = var.create_vpc_network ? 1 : 0
-  description     = "Allow egress to PSA reserved range used for AlloyDB"
+  description     = "Allow private HTTPS access to google services that bypass GFE (Composer 3)"
   action          = "allow"
   direction       = "EGRESS"
   enable_logging  = true
   firewall_policy = google_compute_network_firewall_policy.policy[0].name
-  priority        = 1010
-  rule_name       = "allow-psa-to-alloydb"
+  priority        = 1020
+  rule_name       = "allow-google-apis-directpath"
 
   match {
-    dest_ip_ranges = ["${var.psa_reserved_address}/24"]
+    dest_ip_ranges = ["34.126.0.0/18"]
     layer4_configs {
       ip_protocol = "tcp"
-      ports       = ["5433"]
     }
   }
 }

--- a/components/doc-deletion/src/doc_deletion_main.py
+++ b/components/doc-deletion/src/doc_deletion_main.py
@@ -71,7 +71,7 @@ def init_connection_pool(connector: Connector) -> Engine:
             db=os.environ["ALLOYDB_DATABASE"],
             enable_iam_auth=True,
             user=os.environ["ALLOYDB_USER_CONFIG"],
-            ip_type=IPTypes.PRIVATE,
+            ip_type=IPTypes.PSC,
         )
         return conn
 

--- a/components/post-setup-config/src/dbconfig_main.py
+++ b/components/post-setup-config/src/dbconfig_main.py
@@ -61,7 +61,7 @@ def init_connection_pool(connector: Connector) -> sqlalchemy.engine.Engine:
             db=os.environ["ALLOYDB_DATABASE"],
             enable_iam_auth=True,
             user=os.environ["ALLOYDB_USER_CONFIG"],
-            ip_type=IPTypes.PRIVATE,
+            ip_type=IPTypes.PSC,
         )
         return conn
 

--- a/components/specialized-parser/src/runner.py
+++ b/components/specialized-parser/src/runner.py
@@ -152,7 +152,7 @@ class SpecializedParserJobRunner:
                 db=alloydb_config.database,
                 enable_iam_auth=True,
                 user=alloydb_config.user,
-                ip_type=IPTypes.PRIVATE,
+                ip_type=IPTypes.PSC,
             )
             return conn
 

--- a/sample-deployments/composer-orchestrated-process/main.tf
+++ b/sample-deployments/composer-orchestrated-process/main.tf
@@ -34,7 +34,6 @@ module "common_infra" {
   vpc_name                          = var.vpc_name
   serverless_connector_subnet       = var.serverless_connector_subnet
   serverless_connector_subnet_range = var.serverless_connector_subnet_range
-  psa_reserved_address              = var.psa_reserved_address
   composer_cidr                     = var.composer_cidr
 }
 

--- a/sample-deployments/composer-orchestrated-process/variables.tf
+++ b/sample-deployments/composer-orchestrated-process/variables.tf
@@ -90,9 +90,3 @@ variable "serverless_connector_subnet_range" {
   type        = string
   default     = "10.2.0.0/24"
 }
-
-variable "psa_reserved_address" {
-  description = "First address of CIDR range to reserve for the Private Services Access connection used by AlloyDB. The prefix_length is configured separately in terraform."
-  type        = string
-  default     = "10.11.0.0"
-}


### PR DESCRIPTION
Upgrade PSA to PSC for alloydb. PSA works, but its a legacy network construct that oftens leads to friction with IP allocation and peering quota; PSC avoids these issues.